### PR TITLE
System monitor and printer

### DIFF
--- a/System/SystemMonitor.sh
+++ b/System/SystemMonitor.sh
@@ -4,3 +4,29 @@
 # Abbey Sands
 # Brennan Jackson
 # SystemMonitor - monitors system resource usage
+
+# IP address passed to script
+ip=$1
+
+# Get the network interface card based on the ip address passed in
+nic=$( ifconfig | grep -B 1 "$ip" | awk -F: 'NR==1 {print $1}' )
+
+while true
+do
+	#TODO:Ask about Timing - ifstat has built in delay, around 135s it adds on extra second - clarify against document as well
+
+	# get network utilizatio with sample after 1 second
+	bandwidth=$( ifstat -i $nic 5 1 | awk 'NR>2 {print $1" "$2}' )	
+	rx=$( echo $bandwidth | cut -d " " -f 1 )
+	tx=$( echo $bandwidth | cut -d " " -f 2 )
+	
+	# Get the disk writes in kB/s
+	diskwrites=$( iostat -d sda | grep sda | awk '{print $4}' )
+       	
+	
+	# Get disk utilization for '/' mount in MB
+	diskutil=$( df -BM / | awk 'NR==2{print $4}' | egrep -o [0-9] | tr -d "\n" )
+
+	echo "$SECONDS, $rx, $tx, $diskwrites, $diskutil"
+done
+

--- a/System/SystemMonitor.sh
+++ b/System/SystemMonitor.sh
@@ -11,23 +11,16 @@ ip=$1
 # Get the network interface card based on the ip address passed in
 nic=$( ifconfig | grep -B 1 "$ip" | awk -F: 'NR==1 {print $1}' )
 
-while true
-do
-	#TODO:Ask about Timing - ifstat has built in delay, around 135s it adds on extra second - clarify against document as well
+# get network utilizatio with sample after 1 second
+bandwidth=$( ifstat -t 1 $nic | awk 'NR==4 {print $6" "$8}' )	
+rx=$( echo $bandwidth | cut -d " " -f 1 | sed 's/K//g' )
+tx=$( echo $bandwidth | cut -d " " -f 2 )
+	
+# Get the disk writes in kB/s
+diskwrites=$( iostat -d sda | grep sda | awk '{print $4}' )       	
+	
+# Get disk utilization for '/' mount in MB
+diskutil=$( df -BM / | awk 'NR==2{print $4}' | egrep -o [0-9] | tr -d "\n" )
 
-	# get network utilizatio with sample after 1 second
-	bandwidth=$( ifstat -t 1 $nic | awk 'NR==4 {print $6" "$8}' )	
-	rx=$( echo $bandwidth | cut -d " " -f 1 | sed 's/K//g' )
-	tx=$( echo $bandwidth | cut -d " " -f 2 )
-	
-	# Get the disk writes in kB/s
-	diskwrites=$( iostat -d sda | grep sda | awk '{print $4}' )
-       	
-	
-	# Get disk utilization for '/' mount in MB
-	diskutil=$( df -BM / | awk 'NR==2{print $4}' | egrep -o [0-9] | tr -d "\n" )
-	
-	sleep 5
-	echo "$SECONDS, $rx, $tx, $diskwrites, $diskutil"
-done
-
+# echo out results	
+echo "$rx,$tx,$diskwrites,$diskutil"

--- a/System/SystemMonitor.sh
+++ b/System/SystemMonitor.sh
@@ -16,8 +16,8 @@ do
 	#TODO:Ask about Timing - ifstat has built in delay, around 135s it adds on extra second - clarify against document as well
 
 	# get network utilizatio with sample after 1 second
-	bandwidth=$( ifstat -i $nic 5 1 | awk 'NR>2 {print $1" "$2}' )	
-	rx=$( echo $bandwidth | cut -d " " -f 1 )
+	bandwidth=$( ifstat -t 1 $nic | awk 'NR==4 {print $6" "$8}' )	
+	rx=$( echo $bandwidth | cut -d " " -f 1 | sed 's/K//g' )
 	tx=$( echo $bandwidth | cut -d " " -f 2 )
 	
 	# Get the disk writes in kB/s
@@ -26,7 +26,8 @@ do
 	
 	# Get disk utilization for '/' mount in MB
 	diskutil=$( df -BM / | awk 'NR==2{print $4}' | egrep -o [0-9] | tr -d "\n" )
-
+	
+	sleep 5
 	echo "$SECONDS, $rx, $tx, $diskwrites, $diskutil"
 done
 

--- a/System/SystemPrinter.sh
+++ b/System/SystemPrinter.sh
@@ -4,3 +4,37 @@
 # Abbey Sands
 # Brennan Jackson
 # SystemPrinter - prints results sent by the System monitor to a csv file
+# Also controls timing and the loop for system monitoring
+
+# catch function - removes temp file
+remove_temp () {
+	rm -f temp.txt
+}
+
+trap remove_temp EXIT
+
+# ip passed in as first arg
+ip=$1
+
+if [ -e system_metrics.csv ]
+then
+	rm -f system_metrics.csv
+fi
+
+# make the log file
+touch system_metrics.csv
+
+# run the loop until told not to
+while true
+do
+	# run the system monitor commands in the background to avoid delays caused by the 1 second sample in ifstat
+	# errors are ignored
+	./SystemMonitor.sh $ip > temp.txt 2> /dev/null &
+	
+	# sleep for 5 seconds
+	sleep 5
+	
+	# print the script runtime and the system monitor results to the log file
+	echo "$SECONDS,$(<temp.txt)" >> system_metrics.csv 
+
+done


### PR DESCRIPTION
The system monitor should be all set, printer and all. I messed with the printer and have it calling systemmonitor since the sample ifstat takes causes a small delay. The systemmonitor is called in the background now and the results are written to a temp file. The printer uses the temp file to echo out results and the time to the csv file.